### PR TITLE
Update to use 'Bearer' HTTP header instead of 'Authorization'

### DIFF
--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -63,7 +63,9 @@ final class HttpTransporter implements TransporterContract
         }
 
         if (isset($response['error'])) {
-            throw new ErrorException($response['error']);
+            throw new ErrorException([
+                'message' => $response['error']
+            ]);
         }
 
         return $response;
@@ -89,7 +91,9 @@ final class HttpTransporter implements TransporterContract
             $response = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
 
             if (isset($response['error'])) {
-                throw new ErrorException($response['error']);
+                throw new ErrorException([
+                    'message' => $response['error']
+                ]);    
             }
         } catch (JsonException) {
             // ..

--- a/src/ValueObjects/Transporter/Headers.php
+++ b/src/ValueObjects/Transporter/Headers.php
@@ -36,7 +36,7 @@ final class Headers
     public static function withAuthorization(ApiKey $apiKey): self
     {
         return new self([
-            'Authorization' => "Bearer {$apiKey->toString()}",
+            'Bearer' => $apiKey->toString(),
         ]);
     }
 


### PR DESCRIPTION
HuggingFace API was returning this message:

`Authorization header is invalid, use 'Bearer API_TOKEN'`

I assume they have changed their auth code since this library was written. 

Furthermore, the `HttpTransporter` was throwing a string, but `ErrorException` requires an array.

This should close issue #1 